### PR TITLE
Support activity types

### DIFF
--- a/models/discord.py
+++ b/models/discord.py
@@ -15,6 +15,7 @@ class ActivityButton(TypedDict):
 	url: str
 
 class Activity(TypedDict, total = False):
+	type: int
 	details: str
 	state: str
 	assets: ActivityAssets


### PR DESCRIPTION
Since [Discord supports activity types](https://x.com/advaithj1/status/1816655583107510517) via the RPC APIs now, I figured this should be a nice addition to the app

<img width="285" alt="Screenshot 2024-08-20 at 21 50 56" src="https://github.com/user-attachments/assets/bd0f0d1e-c7a8-40f3-b0bd-aa9421cb03ae">

Thanks for making the amazing project!