### PR TITLE
Add support for Discord's new progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The config file is stored in a directory named `data`.
   * `year` (boolean, default: `true`) - Displays the release year.
   * `statusIcon` (boolean, default: `false`) - Displays a status icon (playing, paused, buffering) at the bottom-right corner of the poster. Applicable to movies and TV shows only. Posters get cropped to a square if this is enabled (Discord bug/limitation).
   * `remainingTime` (boolean, default: `false`) - Displays remaining time instead of elapsed time. This is currently broken due to a Discord bug/limitation.
+  * `progressBar` (boolean, default: `false`) - Whether or not to use Discord's new progress bar. `remainingTime` is ignored if the progress bar is enabled.
   * `paused` (boolean, default: `false`) - Displays Rich Presence even while media is paused. Timestamp while paused is currently broken due to a Discord bug/limitation.
   * `posters`
     * `enabled` (boolean, default: `false`) - Displays media posters (including album art and artist images). Requires `imgurClientID`.

--- a/core/config.py
+++ b/core/config.py
@@ -19,6 +19,7 @@ config: models.config.Config = {
 		"year": True,
 		"statusIcon": False,
 		"remainingTime": False,
+		"progressBar": False,
 		"paused": False,
 		"posters": {
 			"enabled": False,

--- a/core/plex.py
+++ b/core/plex.py
@@ -351,7 +351,12 @@ class PlexAlertListener(threading.Thread):
 				activity["buttons"] = buttons[:2]
 		if state == "playing":
 			currentTimestamp = int(time.time() * 1000)
-			if config["display"]["remainingTime"]:
+			if config["display"]["progressBar"]:
+				activity["timestamps"] = {
+					"start": round(currentTimestamp - viewOffset),
+					"end": round(currentTimestamp + (item.duration - viewOffset))
+				}
+			elif config["display"]["remainingTime"]:
 				activity["timestamps"] = { "end": round(currentTimestamp + (item.duration - viewOffset)) }
 			else:
 				activity["timestamps"] = { "start": round(currentTimestamp - viewOffset) }

--- a/models/config.py
+++ b/models/config.py
@@ -21,6 +21,7 @@ class Display(TypedDict):
 	year: bool
 	statusIcon: bool
 	remainingTime: bool
+	progressBar: bool
 	paused: bool
 	posters: Posters
 	buttons: list[Button]


### PR DESCRIPTION
Closes #97 

I have added opt-in support for Discord's new progress bar that RPCs can use. The images that I included in the issue can be found below. I also know that the close-pull-requests workflow will immediately close it but from previous PRs, I am aware that you still acknowledge them.

![mini-view](https://cdn.serenmodz.rocks/xpx-ORZZ.png)
![full-view](https://cdn.serenmodz.rocks/b9vCzc1l.png)